### PR TITLE
Dalton Muck: Add OpenRouter support and improve LLM platform configuration

### DIFF
--- a/wordle/src/constants.py
+++ b/wordle/src/constants.py
@@ -50,10 +50,12 @@ LETTERS = [
 MIN_NUM_GUESSES = 5
 MIN_LETTERS_TO_ADD = 3
 
-LLM_MODEL: ChatModel = "gpt-4.1"
+LLM_MODEL: ChatModel = "gpt-3.5-turbo"
 OLLAMA_MODEL = "gemma3:latest"
+OPENROUTER_MODEL = "openai/gpt-oss-20b:free"
+#OPENROUTER_API_KEY = ""
 MAX_LLM_CONTINUOUS_CALLS = 5
 
-LLM_PLATFORM = "openai"
+LLM_PLATFORM = "openrouter"
 LOG_LLM_MESSAGES = False
 ERROR_MESSAGE_VISIBLE_TIME = 5

--- a/wordle/src/visuals/config_screen.py
+++ b/wordle/src/visuals/config_screen.py
@@ -27,10 +27,10 @@ def generate_buttons():
             425, cell_width, cell_width
         ), 0, 3, (58, 58, 60), str(i), 65, (255, 255, 255)))
 
-    for i, llm in enumerate(["openai", "gemini", "ollama"]):
+    for i, llm in enumerate(["openai", "openrouter", "gemini", "ollama"]):
         buttons.append(Button(pygame.Rect(
-            100 + (total_width / 3 + 3) * i,
-            600, total_width / 3 - 9, cell_width
+            100 + (total_width / 4 + 3) * i,
+            600, total_width / 4 - 9, cell_width
         ), 0, 3, (58, 58, 60), llm.upper(), 40, (255, 255, 255)))
 
     buttons.append(Button(pygame.Rect(100, 700, total_width, 60),
@@ -47,8 +47,8 @@ def config_screen(game: 'GameState', **kwargs):
 
     lie_buttons: list[Button] = kwargs['buttons'][0:6]
     guess_buttons: list[Button] = kwargs['buttons'][6:10]
-    llm_buttons: list[Button] = kwargs['buttons'][10:13]
-    play_button: Button = kwargs['buttons'][13]
+    llm_buttons: list[Button] = kwargs['buttons'][10:14]
+    play_button: Button = kwargs['buttons'][14]
 
     title = "CONFIG"
     total_width = SCREEN_WIDTH - 80


### PR DESCRIPTION
   ## Add OpenRouter Support
   
   This PR adds OpenRouter as a new LLM platform option to the Wordle AI game.
   
   ### Changes:
   - Added OpenRouter API integration in GameState.py
   - Added OpenRouter configuration constants
   - Updated config screen to include OpenRouter option
   - Improved API key validation and error handling
   - Updated default LLM platform to OpenRouter
   
   ### Testing:
   - All existing functionality preserved
   - New OpenRouter option works with proper API headers
   - UI properly accommodates 4 LLM platform options